### PR TITLE
parsing formatting syntax when we use time global variables

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -38,6 +38,9 @@ function formatDate(name: string, value: string): string {
   if (name === "__from:date" || name === "__to:date" || name === "__from:date:iso" || name === "__to:date:iso") {
     //normal case
     return dayjs(date).toISOString()
+  } else if(name === "__from:date:seconds"){
+    //unix seconds epoch
+    return (parseInt(value) / 1000).toString();;
   } else {
     //by parsing name, we can get the formatter string. ex: YYYY-MM-DD
     try {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -39,7 +39,7 @@ function formatDate(name: string, value: string): string {
   if (name === "__from:date" || name === "__to:date" || name === "__from:date:iso" || name === "__to:date:iso") {
     //normal case
     //no args, defaults to ISO 8601/RFC 3339
-    return dayjs(date).toISOString()
+    return dayjs(date).toISOString();
   } else if(name === "__from:date:seconds"){
     //unix seconds epoch
     const unitSeconds= (parseInt(value) / 1000).toFixed(0);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -33,16 +33,19 @@ const variable = (name: any): string[] => {
   return values;
 };
 
+//This special formatting syntax works only available in Grafana 7.1.2+
 function formatDate(name: string, value: string): string {
   let date = new Date(parseInt(value));
   if (name === "__from:date" || name === "__to:date" || name === "__from:date:iso" || name === "__to:date:iso") {
     //normal case
+    //no args, defaults to ISO 8601/RFC 3339
     return dayjs(date).toISOString()
   } else if(name === "__from:date:seconds"){
     //unix seconds epoch
     return (parseInt(value) / 1000).toString();;
   } else {
     //by parsing name, we can get the formatter string. ex: YYYY-MM-DD
+    //any custom date format that does not include the : character
     try {
       if (name.startsWith("__from:date:")) {
         const formatter = name.substring("__from:date:".length);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,7 +25,6 @@ const variable = (name: any): string[] => {
         values.push(value);
       }
     }
-
     // We don't really care about the string here.
     return '';
   });
@@ -33,7 +32,7 @@ const variable = (name: any): string[] => {
   return values;
 };
 
-//This special formatting syntax works only available in Grafana 7.1.2+
+//Special date formatting syntax follows Global variables
 function formatDate(name: string, value: string): string {
   let date = new Date(parseInt(value, 10));
   if (name === '__from:date' || name === '__to:date' || name === '__from:date:iso' || name === '__to:date:iso') {
@@ -46,7 +45,7 @@ function formatDate(name: string, value: string): string {
     return unitSeconds.toString();
   } else {
     //by parsing name, we can get the formatter string. ex: YYYY-MM-DD
-    //any custom date format that does not include the : character
+    //custom date format depend on dayjs format method.
     try {
       if (name.startsWith('__from:date:')) {
         const formatter = name.substring('__from:date:'.length);
@@ -64,7 +63,6 @@ function formatDate(name: string, value: string): string {
     }
   }
 }
-
 
 const join = (arr: string[], sep: string): string => {
   return arr.join(sep);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -40,7 +40,7 @@ function formatDate(name: string, value: string): string {
     //normal case
     //no args, defaults to ISO 8601/RFC 3339
     return dayjs(date).toISOString();
-  } else if (name === '__from:date:seconds') {
+  } else if (name === '__from:date:seconds' || name === '__to:date:seconds') {
     //unix seconds epoch
     const unitSeconds = (parseInt(value, 10) / 1000).toFixed(0);
     return unitSeconds.toString();

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,5 @@
 import { getTemplateSrv } from '@grafana/runtime';
-import dayjs from 'dayjs'
+import dayjs from 'dayjs';
 
 const date = require('helper-date');
 
@@ -18,7 +18,7 @@ const variable = (name: any): string[] => {
     if (Array.isArray(value)) {
       values.push(...value);
     } else {
-      if (name.startsWith("__from:") || name.startsWith("__to:")) {
+      if (name.startsWith('__from:') || name.startsWith('__to:')) {
         let dateFormattingString = formatDate(name, value);
         values.push(dateFormattingString);
       } else {
@@ -35,24 +35,24 @@ const variable = (name: any): string[] => {
 
 //This special formatting syntax works only available in Grafana 7.1.2+
 function formatDate(name: string, value: string): string {
-  let date = new Date(parseInt(value));
-  if (name === "__from:date" || name === "__to:date" || name === "__from:date:iso" || name === "__to:date:iso") {
+  let date = new Date(parseInt(value, 10));
+  if (name === '__from:date' || name === '__to:date' || name === '__from:date:iso' || name === '__to:date:iso') {
     //normal case
     //no args, defaults to ISO 8601/RFC 3339
     return dayjs(date).toISOString();
-  } else if(name === "__from:date:seconds"){
+  } else if (name === '__from:date:seconds') {
     //unix seconds epoch
-    const unitSeconds= (parseInt(value) / 1000).toFixed(0);
+    const unitSeconds = (parseInt(value, 10) / 1000).toFixed(0);
     return unitSeconds.toString();
   } else {
     //by parsing name, we can get the formatter string. ex: YYYY-MM-DD
     //any custom date format that does not include the : character
     try {
-      if (name.startsWith("__from:date:")) {
-        const formatter = name.substring("__from:date:".length);
+      if (name.startsWith('__from:date:')) {
+        const formatter = name.substring('__from:date:'.length);
         return dayjs(date).format(formatter);
-      } else if (name.startsWith("__to:date:")) {
-        const formatter = name.substring("__to:date:".length);
+      } else if (name.startsWith('__to:date:')) {
+        const formatter = name.substring('__to:date:'.length);
         return dayjs(date).format(formatter);
       } else {
         // if we can not get formatter, return original value

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -19,7 +19,7 @@ const variable = (name: any): string[] => {
       values.push(...value);
     } else {
       if (name.startsWith("__from:") || name.startsWith("__to:")) {
-        let dateFormattingString = formateDate(name, value);
+        let dateFormattingString = formatDate(name, value);
         values.push(dateFormattingString);
       } else {
         values.push(value);
@@ -33,10 +33,10 @@ const variable = (name: any): string[] => {
   return values;
 };
 
-function formateDate(name: string, value: string): string {
+function formatDate(name: string, value: string): string {
   let date = new Date(parseInt(value));
   if (name === "__from:date" || name === "__to:date" || name === "__from:date:iso" || name === "__to:date:iso") {
-    //normal case 
+    //normal case
     return dayjs(date).toISOString()
   } else {
     //by parsing name, we can get the formatter string. ex: YYYY-MM-DD

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -42,7 +42,8 @@ function formatDate(name: string, value: string): string {
     return dayjs(date).toISOString()
   } else if(name === "__from:date:seconds"){
     //unix seconds epoch
-    return (parseInt(value) / 1000).toString();;
+    const unitSeconds= (parseInt(value) / 1000).toFixed(0);
+    return unitSeconds.toString();
   } else {
     //by parsing name, we can get the formatter string. ex: YYYY-MM-DD
     //any custom date format that does not include the : character


### PR DESCRIPTION
Hi, Marcus.

I wrote some code to solve [#82]

- I also use [dayjs](https://github.com/iamkun/dayjs)
- time formatting syntax follows [Global variables](https://grafana.com/docs/grafana/latest/variables/variable-types/global-variables/)


![image](https://user-images.githubusercontent.com/60870275/156323348-84a190df-6519-44d9-8a88-77815fbf04b5.png)



